### PR TITLE
Update readme fix repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,15 +454,15 @@ To run the PHPUnit tests at the command line, go to the tests directory and issu
 
 This library attempts to comply with [PSR-1](http://www.php-fig.org/psr/psr-1/), [PSR-2](http://www.php-fig.org/psr/psr-2/), [PSR-4](http://www.php-fig.org/psr/psr-4/) and [PSR-7](http://www.php-fig.org/psr/psr-7/).
 
-If you notice compliance oversights, please send a patch via [Pull Request](https://github.com/nilportugues/symfony2-haljson-transformer/pulls).
+If you notice compliance oversights, please send a patch via [Pull Request](https://github.com/nilportugues/symfony2-hal-json-transformer/pulls).
 
 
 ## Contribute
 
 Contributions to the package are always welcome!
 
-* Report any bugs or issues you find on the [issue tracker](https://github.com/nilportugues/symfony2-haljson-transformer/issues/new).
-* You can grab the source code at the package's [Git repository](https://github.com/nilportugues/symfony2-haljson-transformer).
+* Report any bugs or issues you find on the [issue tracker](https://github.com/nilportugues/symfony2-hal-json-transformer/issues/new).
+* You can grab the source code at the package's [Git repository](https://github.com/nilportugues/symfony2-hal-json-transformer).
 
 
 ## Support
@@ -470,14 +470,14 @@ Contributions to the package are always welcome!
 Get in touch with me using one of the following means:
 
  - Emailing me at <contact@nilportugues.com>
- - Opening an [Issue](https://github.com/nilportugues/symfony2-haljson-transformer/issues/new)
+ - Opening an [Issue](https://github.com/nilportugues/symfony2-hal-json-transformer/issues/new)
  - Using Gitter: [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nilportugues/symfony2-haljson-transformer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 
 ## Authors
 
 * [Nil Portugués Calderó](http://nilportugues.com)
-* [The Community Contributors](https://github.com/nilportugues/symfony2-haljson-transformer/graphs/contributors)
+* [The Community Contributors](https://github.com/nilportugues/symfony2-hal-json-transformer/graphs/contributors)
 
 
 ## License


### PR DESCRIPTION
This PR fixes the broken links pointing to a bad URL `symfony2-haljson-transformer` instead of `symfony2-hal-json-transformer` at several links.
